### PR TITLE
add: import for google font

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,8 @@
+/*-----  Google Font Import - Quicksand Font -----*/
+
+@import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@300;400;500;600;700&display=swap');
+
+
 /*----- ROOT VARIABLES -----*/
 :root {
     --black: #1F1F1F;


### PR DESCRIPTION
import added to top of css for the google font quicksand

• on code refactor - we will need to remove any weights that aren't being utilised
• To do - add the font-family as a variable in the root? 