### PR TITLE
fixed: link for social media sharing

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Found in Translation" />
     <meta property="og:description"
         content="Found in Translation - Find your tribe, lose the language barrier!" />
-    <meta name="image" property="og:image" content="{{ url_for('static', filename='images/site-responsive.png') }}" />
+    <meta name="image" property="og:image" content="https://imgur.com/a/kPqb4b3" />
     <meta property="og:image:alt"
         content="Found in Translation site shown on a variety of devices" />
     <meta property="og:url" content="https://foundintranslationsodaci.herokuapp.com/" />


### PR DESCRIPTION
Spoke to Abi this morning and her suggestion was to host the image and then add the link into meta tag

